### PR TITLE
hotfix: issue where a user steals someone elses token & tries logging in🚑️

### DIFF
--- a/packages/types/src/validations/user.validations.ts
+++ b/packages/types/src/validations/user.validations.ts
@@ -45,7 +45,7 @@ export const LoginUserBodySchema = CreateUserBodySchema.omit({
       required_error: "username/email is required",
     })
     .trim()
-    .min(5, "username should be atleast 5 characters")
+    .min(5, "username/email should be atleast 5 characters")
     .toLowerCase(),
   email: z.string().email("Invalid email address").optional(),
 });


### PR DESCRIPTION
There was an issue where a user might steal a token or log out to log into another account but the previous token is still there for unknown reasons. The backend would throw an internal server error in these cases due to entered details and session mismatch.

This PR fixes this issue by destroying the session token in such cases and try to log in with the details provided